### PR TITLE
Add arrow operator and $$ operator

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -20,7 +20,7 @@ export default class Tokenizer {
   constructor(cfg) {
     this.WHITESPACE_REGEX = /^(\s+)/u;
     this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
-    this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|=>|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|.)/;
+    this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|=>|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|.)/u;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;
     this.LINE_COMMENT_REGEX = this.createLineCommentRegex(cfg.lineCommentTypes);

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -20,7 +20,7 @@ export default class Tokenizer {
   constructor(cfg) {
     this.WHITESPACE_REGEX = /^(\s+)/u;
     this.NUMBER_REGEX = /^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b/u;
-    this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|.)/u;
+    this.OPERATOR_REGEX = /^(!=|<>|==|<=|>=|=>|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|.)/;
 
     this.BLOCK_COMMENT_REGEX = /^(\/\*[^]*?(?:\*\/|$))/u;
     this.LINE_COMMENT_REGEX = this.createLineCommentRegex(cfg.lineCommentTypes);
@@ -83,18 +83,19 @@ export default class Tokenizer {
   // 3. double quoted string using "" or \" to escape
   // 4. single quoted string using '' or \' to escape
   // 5. national character quoted string using N'' or N\' to escape
+  // 6. $$ as a string seperator
   createStringPattern(stringTypes) {
     const patterns = {
-      '``': '((`[^`]*($|`))+)',
-      '[]': '((\\[[^\\]]*($|\\]))(\\][^\\]]*($|\\]))*)',
-      '""': '(("[^"\\\\]*(?:\\\\.[^"\\\\]*)*("|$))+)',
+      "``": "((`[^`]*($|`))+)",
+      "[]": "((\\[[^\\]]*($|\\]))(\\][^\\]]*($|\\]))*)",
+      "\"\"": "((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"|$))+)",
       "''": "(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('|$))+)",
-      "N''": "((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('|$))+)"
+      "N''": "((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('|$))+)",
+      "$$": "((\\$\\$[^\\$]*($|\\$\\$))+)"
     };
 
-    return stringTypes.map(t => patterns[t]).join('|');
+    return stringTypes.map(t => patterns[t]).join("|");
   }
-
   createParenRegex(parens) {
     return new RegExp('^(' + parens.map(p => this.escapeParen(p)).join('|') + ')', 'iu');
   }

--- a/src/languages/Db2Formatter.js
+++ b/src/languages/Db2Formatter.js
@@ -569,7 +569,7 @@ export default class Db2Formatter {
         reservedTopLevelWords,
         reservedNewlineWords,
         reservedTopLevelWordsNoIndent,
-        stringTypes: [`""`, "''", '``', '[]'],
+        stringTypes: [`""`, "''", "``", "[]", "$$"],
         openParens: ['('],
         closeParens: [')'],
         indexedPlaceholderTypes: ['?'],

--- a/src/languages/N1qlFormatter.js
+++ b/src/languages/N1qlFormatter.js
@@ -242,7 +242,7 @@ export default class N1qlFormatter {
         reservedTopLevelWords,
         reservedNewlineWords,
         reservedTopLevelWordsNoIndent,
-        stringTypes: [`""`, "''", '``'],
+        stringTypes: [`""`, "''", "``","$$"],
         openParens: ['(', '[', '{'],
         closeParens: [')', ']', '}'],
         namedPlaceholderTypes: ['$'],

--- a/src/languages/PlSqlFormatter.js
+++ b/src/languages/PlSqlFormatter.js
@@ -444,7 +444,7 @@ export default class PlSqlFormatter {
         reservedTopLevelWords,
         reservedNewlineWords,
         reservedTopLevelWordsNoIndent,
-        stringTypes: [`""`, "N''", "''", '``'],
+        stringTypes: [`""`, "N''", "''", "``","$$"],
         openParens: ['(', 'CASE'],
         closeParens: [')', 'END'],
         indexedPlaceholderTypes: ['?'],

--- a/src/languages/StandardSqlFormatter.js
+++ b/src/languages/StandardSqlFormatter.js
@@ -345,7 +345,7 @@ export default class StandardSqlFormatter {
         reservedTopLevelWords,
         reservedNewlineWords,
         reservedTopLevelWordsNoIndent,
-        stringTypes: [`""`, "N''", "''", '``', '[]'],
+        stringTypes: [`""`, "N''", "''", "``", "[]", "$$"],
         openParens: ['(', 'CASE'],
         closeParens: [')', 'END'],
         indexedPlaceholderTypes: ['?'],

--- a/test/behavesLikeSqlFormatter.js
+++ b/test/behavesLikeSqlFormatter.js
@@ -526,4 +526,35 @@ export default function behavesLikeSqlFormatter(language) {
       );
     `);
   });
+
+  it("formats $$ correctly", function() {
+    const result = format(dedent/* sql */`
+      CREATE
+      OR REPLACE FUNCTION RECURSION_TEST (STR VARCHAR) RETURNS VARCHAR LANGUAGE JAVASCRIPT AS $$
+      return (STR.length <= 1
+       ? STR : STR.substring(0,1) + '_' + RECURSION_TEST(STR.substring(1)));
+      $$;
+    `);
+
+    expect(result).toBe(dedent/* sql */`
+      CREATE
+      OR REPLACE FUNCTION RECURSION_TEST (STR VARCHAR) RETURNS VARCHAR LANGUAGE JAVASCRIPT AS $$
+      return (STR.length <= 1
+       ? STR : STR.substring(0,1) + '_' + RECURSION_TEST(STR.substring(1)));
+      $$;
+    `);
+  });
+
+  it("formats => correctly", function() {
+    const result = format(
+      `select seq4(), uniform(1, 10, random(12)) from table(generator(rowcount => 11000)) v`
+    );
+    expect(result).toBe(dedent/* sql */`
+      select
+        seq4(),
+        uniform(1, 10, random(12))
+      from
+        table(generator(rowcount => 11000)) v
+    `);
+  });
 }


### PR DESCRIPTION
Format Query feature was adding an undesired space for operators and $$

Example:
select seq4(), uniform(1, 10, random(12)) from table(generator(rowcount => 11000)) v
would get formatted into:
select seq4(), uniform(1, 10, random(12)) from table(generator(rowcount = > 11000)) v;